### PR TITLE
Added example of themedir option in README usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ grunt.initConfig({
       url: '<%= pkg.homepage %>',
       options: {
         paths: 'path/to/source/code/',
+        themedir: 'path/to/custom/theme/',
         outdir: 'where/to/save/docs/'
       }
     }


### PR DESCRIPTION
As discussed in issue #10 I have added an example of using `themedir` to the README.
