### PR TITLE
Adding try/catch for errors thrown when YUIDoc dislikes options

### DIFF
--- a/tasks/yuidoc.js
+++ b/tasks/yuidoc.js
@@ -53,14 +53,10 @@ module.exports = function(grunt) {
       options.paths = [ options.paths ];
     }
     
-    // Try to parse the options, catch and hand off to stdout handler.
-    //  YUIDoc will throw errors if:
-    //      ... Can not find directory: ./path/doesn't/exist/
-    //      ... Cannot read property 'name' of undefined
     try {
       json = (new Y.YUIDoc(options)).run();
     } catch(e) {
-      grunt.fail.warn('Encountered a problem with your project options (' + e + ')', 1);
+      grunt.warn(e);
     }
 
     options = Y.Project.mix(json, options);


### PR DESCRIPTION
Added a simple `try/catch` where Grunt options are parsed for the `yuidoc` task.  With bad options (easy mistake for a new user of the package), the task fails without much feedback.  The `try/catch` hands off the error to stdout via Grunt's fail/warn handler.

Sets a Grunt [exit code](http://gruntjs.com/exit-codes) of `1`, "Fatal error".
