### PR TITLE
Add support for linting.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -17,7 +17,8 @@ module.exports = function(grunt) {
       all: [
         'Gruntfile.js',
         'tasks/*.js',
-        '<%= nodeunit.tests %>'
+        '<%= nodeunit.compile %>',
+        '<%= nodeunit.lint %>',
       ],
       options: {
         jshintrc: '.jshintrc'
@@ -42,6 +43,17 @@ module.exports = function(grunt) {
         }
       },
 
+      lintA: {
+        'name': 'Grunt Test',
+        'description': 'Grunt Test Description',
+        'version': '1.2.1',
+        'url': 'http://test.com',
+        options: {
+          lint: true,
+          paths: 'test/fixtures/app'
+        }
+      },
+
       compileB: {
         'name': 'Grunt Test',
         'description': 'Grunt Test Description',
@@ -56,6 +68,20 @@ module.exports = function(grunt) {
         }
       },
 
+      lintB: {
+        'name': 'Grunt Test',
+        'description': 'Grunt Test Description',
+        'version': '1.2.1',
+        'url': 'http://test.com/',
+        options: {
+          lint: true,
+          paths: [
+            'test/fixtures/app/',
+            'test/fixtures/otherapp/'
+          ]
+        }
+      },
+
       compileC: {
         'name': "Grunt Test <%= 'Title' %>",
         'description': 'Description Text for <%= pkg.name %>',
@@ -65,12 +91,24 @@ module.exports = function(grunt) {
           paths: 'test/fixtures/app/',
           outdir: 'tmp/yuidocc/'
         }
-      }
+      },
+
+      lintC: {
+        'name': "Grunt Test <%= 'Title' %>",
+        'description': 'Description Text for <%= pkg.name %>',
+        'version': '<%= pkg.version %>',
+        'url': 'http://test.com/',
+        options: {
+          lint: true,
+          paths: 'test/fixtures/app/'
+        }
+      },
     },
 
     // Unit tests.
     nodeunit: {
-      tests: ['test/*_test.js']
+      compile: ['test/yuidoc_test.js'],
+      lint: ['test/lint_test.js']
     }
   });
 
@@ -85,7 +123,17 @@ module.exports = function(grunt) {
 
   // Whenever the "test" task is run, first clean the "tmp" dir, then run this
   // plugin's task(s), then test the result.
-  grunt.registerTask('test', ['clean', 'yuidoc', 'nodeunit']);
+  grunt.registerTask('test', [
+    'clean',
+    'yuidoc:lintA',
+    'yuidoc:lintB',
+    'yuidoc:lintC',
+    'nodeunit:lint',
+    'yuidoc:compileA',
+    'yuidoc:compileB',
+    'yuidoc:compileC',
+    'nodeunit:compile'
+  ]);
 
   // By default, lint and run all tests.
   grunt.registerTask('default', ['jshint', 'test', 'build-contrib']);

--- a/README.md
+++ b/README.md
@@ -26,10 +26,10 @@ grunt.loadNpmTasks('grunt-contrib-yuidoc');
 ## Yuidoc task
 _Run this task with the `grunt yuidoc` command._
 
-[Visit the YUIDoc project home](http://yui.github.io/yuidoc/) for more information on YUIDocs and commenting syntax.
+[Visit the YUIDoc project home](http://yui.github.com/yuidoc/) for more information on YUIDocs and commenting syntax.
 ### Options
 
-Settings mirror [YUIDoc config](http://yui.github.io/yuidoc/args/index.html).
+Settings mirror [YUIDoc config](http://yui.github.com/yuidoc/args/index.html).
 ### Usage Examples
 
 ```js
@@ -67,4 +67,4 @@ grunt.initConfig({
 
 Task submitted by [George Pantazis](http://georgepantazis.com/)
 
-*This file was generated on Sun Sep 01 2013 13:01:10.*
+*This file was generated on Sun Jan 05 2014 22:35:56.*

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "test": "grunt test"
   },
   "dependencies": {
-    "yuidocjs": "~0.3.45"
+    "yuidocjs": "git://github.com/yui/yuidoc.git#f946bf396596293183b67cddb4ce76efc6712dbc"
   },
   "devDependencies": {
     "grunt-contrib-jshint": "~0.6.2",

--- a/tasks/yuidoc.js
+++ b/tasks/yuidoc.js
@@ -39,27 +39,38 @@ module.exports = function(grunt) {
     if ( !options.paths ) {
       grunt.fail.warn('No path(s) provided for YUIDoc to scan.');
     }
-    if ( !options.outdir ) {
+
+    // Must specify outdir, unless linting.
+    if ( !options.outdir && !options.lint ) {
       grunt.fail.warn('You must specify a directory for YUIDoc output.');
     }
 
-    // ensure destination dir is available
-    grunt.file.mkdir(options.outdir);
+    // No need to generate outdir if linting.
+    if ( !options.lint ) {
+      // ensure destination dir is available
+      grunt.file.mkdir(options.outdir);
+    }
 
     // Input path: array expected, but grunt conventions allows for either a string or an array.
     if (kindOf(options.paths) === 'string') {
       options.paths = [ options.paths ];
     }
-    
+
     try {
       json = (new Y.YUIDoc(options)).run();
     } catch(e) {
       grunt.warn(e);
     }
 
+    // If linting, exit now and do not build documentation.
+    if (options.lint) {
+      done();
+      return;
+    }
+
     options = Y.Project.mix(json, options);
 
-    if (!options.parseOnly) {
+    if ( !options.parseOnly ) {
       var builder = new Y.DocBuilder(options, json);
 
       grunt.log.writeln('Start YUIDoc compile...');

--- a/test/lint_test.js
+++ b/test/lint_test.js
@@ -1,0 +1,18 @@
+var grunt = require('grunt');
+
+exports.yuidoc = {
+  main: function(test) {
+    'use strict';
+
+    var expect, result, data;
+    test.expect(1);
+
+    expect = true;
+    result = !grunt.file.exists('tmp/yuidoca') &&
+      !grunt.file.exists('tmp/yuidocb') &&
+      !grunt.file.exists('tmp/yuidocc');
+    test.equal(result, expect, 'If linting source, no documentation should be produced.');
+
+    test.done();
+  }
+};


### PR DESCRIPTION
YUIDoc has an option to lint the documentation comments. I recently submitted a pull request to the YUIDoc repo with changes that make it possible to lint the doc comments as a Grunt task. The pull request was merged today. These are my modifications to add support for linting. YUIDoc linting **does not** produce any documentation files.
