### PR TITLE
Bump yuidocjs version to 0.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "test": "grunt test"
   },
   "dependencies": {
-    "yuidocjs": "~0.4.0"
+    "yuidocjs": "~0.5.0"
   },
   "devDependencies": {
     "grunt-contrib-jshint": "~0.6.2",


### PR DESCRIPTION
We just released v0.5.0 yesterday. It should be no breaking changes.